### PR TITLE
Feature/include isolation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ on:
       - '*'
     paths:
       - '.github/*'
-      - '*.rs'
+      - '**.rs'
       - 'pyproject.toml'
       - 'Cargo.toml'
       - '*.pyi'

--- a/database/src/conn.rs
+++ b/database/src/conn.rs
@@ -3,6 +3,7 @@ use convert::convert_result_set_as_list;
 use py_types::PyRows;
 use py_types::{py_error, DBError, PySQLXError, PySQLXResult};
 use pyo3::prelude::*;
+use quaint::connector::IsolationLevel;
 use quaint::prelude::*;
 use quaint::single::Quaint;
 
@@ -13,6 +14,7 @@ pub struct Connection {
 }
 
 impl Connection {
+    // create a new connection using the given url
     pub async fn new(uri: String) -> Result<Self, PySQLXError> {
         let conn = match Quaint::new(uri.as_str()).await {
             Ok(r) => r,
@@ -21,31 +23,71 @@ impl Connection {
         Ok(Self { conn })
     }
 
+    // Execute a query given as SQL, interpolating the given parameters. return a PySQLXResult
     async fn _query(&self, sql: &str) -> Result<PySQLXResult, PySQLXError> {
         match self.conn.query_raw(sql, &[]).await {
             Ok(r) => Ok(convert_result_set(r)),
             Err(e) => Err(py_error(e, DBError::QueryError)),
         }
     }
-
+    // Execute a query given as SQL, interpolating the given parameters. return a list of rows
     async fn _query_as_list(&self, sql: &str) -> Result<PyRows, PySQLXError> {
         match self.conn.query_raw(sql, &[]).await {
             Ok(r) => Ok(convert_result_set_as_list(r)),
             Err(e) => Err(py_error(e, DBError::QueryError)),
         }
     }
-
+    // Execute a query given as SQL, interpolating the given parameters and returning the number of affected rows.
     async fn _execute(&self, sql: &str) -> Result<u64, PySQLXError> {
         match self.conn.execute_raw(sql, &[]).await {
             Ok(r) => Ok(r),
             Err(e) => Err(py_error(e, DBError::ExecuteError)),
         }
     }
-
+    // Run a command in the database, for queries that can't be run using prepared statements.
     async fn _raw_cmd(&self, sql: &str) -> Result<(), PySQLXError> {
         match self.conn.raw_cmd(sql).await {
             Ok(_) => Ok(()),
             Err(e) => Err(py_error(e, DBError::ExecuteError)),
+        }
+    }
+    // return the isolation level
+    fn get_isolation_level(&self, isolation_level: String) -> Result<IsolationLevel, PySQLXError> {
+        match isolation_level.to_uppercase().as_str() {
+            "READUNCOMMITTED" => Ok(IsolationLevel::ReadUncommitted),
+            "READCOMMITTED" => Ok(IsolationLevel::ReadCommitted),
+            "REPEATABLEREAD" => Ok(IsolationLevel::RepeatableRead),
+            "SNAPSHOT" => Ok(IsolationLevel::Snapshot),
+            "SERIALIZABLE" => Ok(IsolationLevel::Serializable),
+            _ => {
+                return Err(PySQLXError::new(
+                    "10IVAL".to_string(),
+                    "invalid isolation level".to_string(),
+                    DBError::IsoLevelError,
+                ))
+            }
+        }
+    }
+
+    // Sets the transaction isolation level to given value. Implementers have to make sure that the passed isolation level is valid for the underlying database.
+    async fn _set_isolation_level(&self, isolation_level: String) -> Result<(), PySQLXError> {
+        let level = self.get_isolation_level(isolation_level)?;
+        match self.conn.set_tx_isolation_level(level).await {
+            Ok(_) => Ok(()),
+            Err(e) => Err(py_error(e, DBError::IsoLevelError)),
+        }
+    }
+
+    // Start a new transaction.
+    async fn _start_transaction(&self, isolation_level: Option<String>) -> Result<(), PySQLXError> {
+        let level = match isolation_level {
+            Some(l) => Some(self.get_isolation_level(l)?),
+            None => None,
+        };
+
+        match self.conn.start_transaction(level).await {
+            Ok(_) => Ok(()),
+            Err(e) => Err(py_error(e, DBError::StartTransactionError)),
         }
     }
 }
@@ -103,6 +145,34 @@ impl Connection {
             }
         })
     }
+
+    pub fn set_isolation_level<'a>(
+        &mut self,
+        py: Python<'a>,
+        isolation_level: String,
+    ) -> PyResult<&'a PyAny> {
+        let slf = self.clone();
+        pyo3_asyncio::tokio::future_into_py(py, async move {
+            match slf._set_isolation_level(isolation_level).await {
+                Ok(_) => Ok(()),
+                Err(e) => Err(e.to_pyerr()),
+            }
+        })
+    }
+
+    pub fn start_transaction<'a>(
+        &mut self,
+        py: Python<'a>,
+        isolation_level: Option<String>,
+    ) -> PyResult<&'a PyAny> {
+        let slf = self.clone();
+        pyo3_asyncio::tokio::future_into_py(py, async move {
+            match slf._start_transaction(isolation_level).await {
+                Ok(_) => Ok(()),
+                Err(e) => Err(e.to_pyerr()),
+            }
+        })
+    }
 }
 
 #[cfg(test)]
@@ -112,7 +182,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_connection_query() {
+    async fn test_connection_query_success() {
         let conn = Connection::new("file:///tmp/db.db".to_string())
             .await
             .unwrap();
@@ -121,9 +191,18 @@ mod tests {
         assert_eq!(res.types().len(), 1);
         assert_eq!(res.types().get("number").unwrap(), "int");
     }
-    #[tokio::test]
 
-    async fn test_connection_execute() {
+    #[tokio::test]
+    async fn test_connection_query_error() {
+        let conn = Connection::new("file:///tmp/db.db".to_string())
+            .await
+            .unwrap();
+        let res = conn._query("SELECT * FROM InvalidTable").await;
+        assert!(res.is_err())
+    }
+
+    #[tokio::test]
+    async fn test_connection_execute_success() {
         let conn = Connection::new("file:///tmp/db.db".to_string())
             .await
             .unwrap();
@@ -141,7 +220,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_query_as_list() {
+    async fn test_connection_execute_error() {
+        let conn = Connection::new("file:///tmp/db.db".to_string())
+            .await
+            .unwrap();
+        let res = conn._execute("CREATE TABL test (id int)").await;
+        assert!(res.is_err())
+    }
+
+    #[tokio::test]
+    async fn test_query_as_list_success() {
         let conn = Connection::new("file:///tmp/db.db".to_string())
             .await
             .unwrap();
@@ -159,5 +247,63 @@ mod tests {
 
         let res = conn._query_as_list("SELECT * FROM test").await.unwrap();
         assert_eq!(res[0].get("id").unwrap(), &PyValue::Int(1));
+    }
+
+    #[tokio::test]
+    async fn test_query_as_list_error() {
+        let conn = Connection::new("file:///tmp/db.db".to_string())
+            .await
+            .unwrap();
+        let res = conn._query_as_list("SELECT * FROM InvalidTable").await;
+        assert!(res.is_err())
+    }
+
+    #[tokio::test]
+    async fn test_raw_cmd_success() {
+        let conn = Connection::new("file:///tmp/db.db".to_string())
+            .await
+            .unwrap();
+        let res = conn
+            ._raw_cmd("CREATE TABLE IF NOT EXISTS test (id int)")
+            .await;
+        assert!(res.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_raw_cmd_error() {
+        let conn = Connection::new("file:///tmp/db.db".to_string())
+            .await
+            .unwrap();
+        let res = conn._raw_cmd("CREATE TABL test (id int)").await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_set_isolation_level_error() {
+        let conn = Connection::new("file:///tmp/db.db".to_string())
+            .await
+            .unwrap();
+        let res = conn._set_isolation_level("InvalidRead".to_string()).await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_start_transaction_success() {
+        let conn = Connection::new("file:///tmp/db.db".to_string())
+            .await
+            .unwrap();
+        let res = conn._start_transaction(None).await;
+        assert!(res.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_start_transaction_error() {
+        let conn = Connection::new("file:///tmp/db.db".to_string())
+            .await
+            .unwrap();
+        let res = conn
+            ._start_transaction(Some("InvalidRead".to_string()))
+            .await;
+        assert!(res.is_err());
     }
 }

--- a/py_types/src/errors.rs
+++ b/py_types/src/errors.rs
@@ -12,6 +12,7 @@ pub enum DBError {
     ExecuteError,
     ConnectionError,
     IsoLevelError,
+    StartTransactionError,
 }
 
 impl ToPyObject for DBError {
@@ -28,6 +29,7 @@ impl<'a> FromPyObject<'a> for DBError {
             "ExecuteError" => Ok(DBError::ExecuteError),
             "ConnectionError" => Ok(DBError::ConnectionError),
             "IsoLevelError" => Ok(DBError::IsoLevelError),
+            "StartTransactionError" => Ok(DBError::StartTransactionError),
             _ => Err(PyTypeError::new_err(format!(
                 "Cannot convert {} to DBError",
                 s
@@ -43,6 +45,7 @@ impl Display for DBError {
             DBError::ExecuteError => "ExecuteError".to_string(),
             DBError::ConnectionError => "ConnectionError".to_string(),
             DBError::IsoLevelError => "IsoLevelError".to_string(),
+            DBError::StartTransactionError => "StartTransactionError".to_string(),
         };
         write!(f, "{}", v)
     }

--- a/pysqlx_core.pyi
+++ b/pysqlx_core.pyi
@@ -1,7 +1,15 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
+from enum import Enum
 __all__ = ("__version__", "new", "Connection", 'PySQLXError', "PySQLXResult")
 __version__: str
 
+class IsolationLevel(Enum):
+    """Isolation levels for transactions."""
+    ReadUncommitted ="ReadUncommitted"
+    ReadCommitted ="ReadCommitted"
+    RepeatableRead ="RepeatableRead"
+    Snapshot ="Snapshot"
+    Serializable ="Serializable"
 
 class PySQLXError(Exception):
     """
@@ -51,7 +59,48 @@ class PySQLXResult:
         raise PySQLXError()
 
 class Connection:
-    """Creates a new connection to the database. Create after calling `new`."""
+    """
+    ## Connection
+    Creates a new connection to the database. Create after calling `new`.
+
+    ### example
+    ``` python
+    import pysqlx_core
+    import asyncio
+    
+    async def main(sql):
+        # Create a connection 
+        db = await pysqlx_core.new(uri="file:///tmp/db.db")
+        
+        # Create a table
+        await db.execute(sql='''
+            CREATE TABLE IF NOT EXISTS test (
+                id SERIAL PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            );
+            '''
+        )
+    
+        # Insert a row and return quantity rows affected
+        await db.execute(sql="INSERT INTO test (name) VALUES ('Carlos');")
+    
+        # Select all rows, return a class PySQLXResult
+        result = await db.query(sql="SELECT * FROM test;")
+        # get first row
+        row = result.get_first() # Dict[str, Any] 
+        # get all rows
+        rows = result.get_all() # List[Dict[str, Any]]
+        #return the db types to Pydantic BaseModel
+        types = result.get_model() # Dict[str, str] 
+    
+        # Select all rows, return how List[Dict[str, Any]]
+        rows = await db.query_as_list(sql="SELECT * FROM test;")
+    
+        # close? no need 👌-> auto-close when finished programmer or go out of context..
+        
+    asyncio.run(main())
+    ```
+    """
     async def query(self, sql: str) -> "PySQLXResult":
         """Returns a `PySQLXResult` object representing the result of the query."""
         raise PySQLXError()
@@ -66,7 +115,7 @@ class Connection:
     
     async def raw_cmd(self, sql: str) -> "str": 
         """Run a command in the database, for queries that can't be run using prepared statements."""
-        ...
+        raise PySQLXError()
 
     def is_healthy(self) -> "bool": 
         """Returns false, if connection is considered to not be in a working state"""
@@ -77,7 +126,7 @@ class Connection:
         This is used to determine if the connection should be isolated before executing a query.
         for example, sqlserver requires isolation before executing a query using begin.
         
-        - Signals if the isolation level SET needs to happen before or after the tx BEGIN
+        - Signals if the isolation level SET needs to happen before or after the BEGIN
 
         * [SQL Server documentation]: (https://docs.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql?view=sql-server-ver15)
         * [Postgres documentation]: (https://www.postgresql.org/docs/current/sql-set-transaction.html)
@@ -85,6 +134,23 @@ class Connection:
         * [SQLite documentation]: (https://www.sqlite.org/isolation.html)
         """
         ...
+
+    async def set_isolation_level(self, isolation_level: "IsolationLevel") -> "None": 
+        """
+        Sets the isolation level of the connection.
+        The isolation level is set before the transaction is started.
+        Is used to separate the transaction per level.
+
+        * [SQL Server documentation]: (https://docs.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql?view=sql-server-ver15)
+        * [Postgres documentation]: (https://www.postgresql.org/docs/current/sql-set-transaction.html)
+        * [MySQL documentation]: (https://dev.mysql.com/doc/refman/8.0/en/innodb-transaction-isolation-levels.html)
+        * [SQLite documentation]: (https://www.sqlite.org/isolation.html)
+        """
+        raise PySQLXError()
+    
+    async def start_transaction(self, isolation_level: "Union[IsolationLevel,None]") -> "None": 
+        """Starts a transaction with BEGIN. by default, does not set the isolation level."""
+        raise PySQLXError()
 
 async def new(uri: str) -> 'Connection':
     """Creates a new connection to the database. Returns a `Connection` object."""


### PR DESCRIPTION
include new features to starting a transaction automatic and set a isolation level.

- set_isolation_level: Sets the transaction isolation level to given value. Implementers have to make sure that the passed isolation level is valid for the underlying database.

- start_transaction: Starts a transaction with BEGIN. by default, does not set the isolation level.