### PR TITLE
refactor: Update PySQLxStatement to generate random strings based on …

### DIFF
--- a/src/py_types/types.rs
+++ b/src/py_types/types.rs
@@ -143,7 +143,7 @@ pub struct PySQLxStatement {
 }
 
 impl PySQLxStatement {
-    fn generate_random_string(length: usize, exist_keys: &Vec<String>) -> String {
+    fn generate_random_string(length: usize, exist_keys: &Vec<String>, sql: &String) -> String {
         // generate random string with length to replace the parameter in the query
         let rand_string: String = thread_rng()
             .sample_iter(&Alphanumeric)
@@ -151,9 +151,9 @@ impl PySQLxStatement {
             .map(char::from)
             .collect();
         // check if the random string is already exist in the keys
-        if exist_keys.contains(&rand_string) {
+        if exist_keys.contains(&rand_string) || sql.contains(&rand_string) {
             // if exist, generate again with length + 1
-            return PySQLxStatement::generate_random_string(length + 1, &exist_keys);
+            return PySQLxStatement::generate_random_string(length + 1, &exist_keys, &sql);
         }
         format!(":{}", rand_string.to_lowercase())
     }
@@ -171,7 +171,7 @@ impl PySQLxStatement {
             let temp = new_sql.clone();
             let matches = temp.match_indices(old_key.as_str());
             for (start, mat) in matches {
-                let new_key = PySQLxStatement::generate_random_string(7, &exist_keys);
+                let new_key = PySQLxStatement::generate_random_string(7, &exist_keys, &new_sql);
 
                 exist_keys.push(new_key.clone());
 


### PR DESCRIPTION
Fix Bug New Keys Generate

The `PySQLxStatement` struct in `types.rs` has been updated to include an additional parameter `sql` in the `generate_random_string` method. This change allows the method to check if the randomly generated string is already present in the SQL query, in addition to the existing check for existing keys. A new string with a longer length is generated if the generated string is already present.

This refactor improves the reliability of the generated random strings and ensures that they do not conflict with existing keys or appear in the SQL query itself.